### PR TITLE
Prefix usernames with @ sign

### DIFF
--- a/gitter.py
+++ b/gitter.py
@@ -91,10 +91,10 @@ class GitterIdentifier(object):
                                 avatarMedium=from_user['avatarUrlMedium'])
 
     def __unicode__(self):
-        return self.username
+        return "@%s" % self.username
 
     __str__ = __unicode__
-    aclattr = nick
+    aclattr = __str__
 
 
 class GitterMUCOccupant(GitterIdentifier):
@@ -321,6 +321,7 @@ class GitterBackend(ErrBot):
         return contacts
 
     def build_identifier(self, strrep):
+        strrep = strrep.lstrip("@")
         # contacts are a kind of special Room
         all_rooms = self.readAPIRequest('rooms')
         for json_room in all_rooms:


### PR DESCRIPTION
I don't know if we want this (main impact is that entries in `BOT_ADMINS` and such will need to be adjusted by current users, changing `zoni` into `@zoni`) , but I think it has some merit so I thought I'd suggest it.

This makes the display similar to when mentions are used on Gitter and/or GitHub and also makes it consistent with how the Slack and HipChat backends denote users (as opposed to channels).
